### PR TITLE
Update `docker build` test to expect BuildKit as the default builder

### DIFF
--- a/action/test/specs/docker.spec.ts
+++ b/action/test/specs/docker.spec.ts
@@ -56,10 +56,10 @@ describe('docker', () => {
         throw err;
       });
 
-    expect(logger.log.mock.calls.length).toBeGreaterThan(1);
-    expect(logger.log.mock.calls[logger.log.mock.calls.length - 1]).toEqual([
-      'Successfully tagged hpc-actions/unit-test:some-tag',
-    ]);
+    expect(logger.error.mock.calls.length).toBeGreaterThan(1);
+    expect(logger.error.mock.calls.at(-2).at(0)).toMatch(
+      'naming to docker.io/hpc-actions/unit-test:some-tag done'
+    );
 
     expect(await docker.getMetadata('some-tag')).toEqual({
       commitSha: 'foo',


### PR DESCRIPTION
Since Docker 23.0.0, [Buildx and BuildKit are the default builder on Linux](https://docs.docker.com/engine/release-notes/23.0/#new), and `docker build` is just an alias to `docker buildx build`. We could keep using legacy builder by setting `DOCKER_BUILDKIT=0`, but that isn't long term solution.

The failing test case is invoking `docker build`, by using `node:child_process` package and thus the test itself has zero control over Docker version, as it only depends on host machine's Docker, so Docker breaking changes can also break this test.

With switch of default Docker builder to Buildx, two changes affected the test case:
1) The output during build [no longer goes to stdout, but stderr](https://github.com/moby/buildkit/issues/1186). We can redirect stderr to stdout by putting `2>&1` at the end of `docker build` command, but that would affect production code as well. Doing it only for tests would require parametrization and unecessary complication of method signatures.
2) Output text has changed significantly, but since we're only matching for final success message, we only need slight adjustments

---

To see the difference in output between Docker builders, I've done a little test. With Docker v24.0.6, I have created the same `Dockerfile` as our failing test case:
https://github.com/UN-OCHA/hpc-actions/blob/33493a6e53c8251589224a0df1d99c694dbcc1c2/action/test/specs/docker.spec.ts#L9-L14
Then, executed [same command which our test case runs](https://github.com/UN-OCHA/hpc-actions/blob/33493a6e53c8251589224a0df1d99c694dbcc1c2/action/src/docker.ts#L123-L126):
```sh
docker build . --build-arg COMMIT_SHA=foo --build-arg TREE_SHA=bar -t hpc-actions/unit-test:some-tag > ~/buildx-stdout.txt 2> ~/buildx-stderr.txt
```
Buildx stdout is empty and Buildx stderr is
```txt
#0 building with "default" instance using docker driver

#1 [internal] load .dockerignore
#1 transferring context: 2B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 157B done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/alpine:3.16
#3 DONE 0.0s

#4 [1/1] FROM docker.io/library/alpine:3.16
#4 CACHED

#5 exporting to image
#5 exporting layers done
#5 writing image sha256:a3c44542f28054a59599a5a3c0449c57c7f153cd2e30a649c09eb3705cd64ea1 done
#5 naming to docker.io/hpc-actions/unit-test:some-tag done
#5 DONE 0.0s
```

However, if we use legacy builder with Docker v24.0.6:
```sh
DOCKER_BUILDKIT=0 docker build . --build-arg COMMIT_SHA=foo --build-arg TREE_SHA=bar -t hpc-actions/unit-test:some-tag > ~/legacy-stdout.txt 2> ~/legacy-stderr.txt
```
In this case, stdout is
```txt
Sending build context to Docker daemon  134.6MB

Step 1/5 : FROM alpine:3.16
 ---> 187eae39ad94
Step 2/5 : ARG COMMIT_SHA
 ---> Using cache
 ---> 615bb996f533
Step 3/5 : ARG TREE_SHA
 ---> Using cache
 ---> a38823d2d635
Step 4/5 : ENV HPC_ACTIONS_COMMIT_SHA $COMMIT_SHA
 ---> Using cache
 ---> 7d162e9f503d
Step 5/5 : ENV HPC_ACTIONS_TREE_SHA $TREE_SHA
 ---> Using cache
 ---> 1892808be2e9
Successfully built 1892808be2e9
Successfully tagged hpc-actions/unit-test:some-tag
```
and stderr is
```txt
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
            environment-variable.
```