### PR TITLE
Remove obsolete comment

### DIFF
--- a/action/src/action.ts
+++ b/action/src/action.ts
@@ -273,16 +273,6 @@ export const runAction = async ({
         };
 
     const buildAndPushDockerImage = async (opts: {
-      /**
-       * How should the registry be checked for existing images with the
-       * same tag before building a new one?
-       *
-       * * `check-tree`: if the image doesn't yet exist, build it, if it does,
-       *   check to see that it was built with the same git tree sha. If it
-       *   was, finish, if not, throw an error.
-       * * `overwrite`: Don't check the registry, just build and push a new
-       *   image.
-       */
       checkBehaviour: null | {
         /**
          * If checkStrict is true,


### PR DESCRIPTION
Before 7be0c1c383aeb48c8e7f49b0fd967cee0fe6cd7d, `checkBehaviour` was accepting two string options: `'check-tree'` and `'overwrite'`, but it no longer does, so the comment explaining these options is obsolete.