### PR TITLE
Update GitHub actions to versions that use `node20` as default runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     name: Run Build and check output is checked-in
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Install NPM Packages
@@ -34,9 +34,9 @@ jobs:
     name: Check file formatting, linting and Typescript types
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Install NPM Packages
@@ -61,9 +61,9 @@ jobs:
     name: Run Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Install NPM Packages
@@ -75,7 +75,7 @@ jobs:
           cd action
           npm run test -- --coverage
       - name: Submit to CodeCov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./action/.coverage/lcov.info
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,5 +77,6 @@ jobs:
       - name: Submit to CodeCov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./action/.coverage/lcov.info
           fail_ci_if_error: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
The original intent was to update GitHub actions to versions that use `node20` as default runtime, because there were warnings in the action runs. After the changes done here, only `technote-space/toc-generator@v4` still receives a warning, because it seems not maintained and there is no Node.js 20 support yet.

But, updating `codecov/codecov-action` to `v4` also required us to supply a token, because CodeCov started requesting it. See HPC-9542 for details.