### PR TITLE
Send repository name in deployment payload

### DIFF
--- a/action/dist/index.js
+++ b/action/dist/index.js
@@ -1123,6 +1123,10 @@ const REAL_GITHUB = ({ token, githubRepo }) => {
                 owner,
                 repo,
                 ...params,
+                payload: {
+                    ...params.payload,
+                    repository_name: params.payload.repository_name ?? repo,
+                },
             });
         },
     };

--- a/action/src/github.ts
+++ b/action/src/github.ts
@@ -36,7 +36,10 @@ export interface GitHubController {
     task: string;
     auto_merge: boolean;
     required_contexts: [];
-    payload: string | { [key: string]: unknown };
+    payload: {
+      docker_tag: string;
+      repository_name?: string;
+    };
     environment: string;
     transient_environment: boolean;
     production_environment: boolean;
@@ -109,6 +112,10 @@ export const REAL_GITHUB: GitHubInit = ({ token, githubRepo }) => {
         owner,
         repo,
         ...params,
+        payload: {
+          ...params.payload,
+          repository_name: params.payload.repository_name ?? repo,
+        },
       });
     },
   };

--- a/action/test/specs/action.spec.ts
+++ b/action/test/specs/action.spec.ts
@@ -1001,6 +1001,7 @@ describe('action', () => {
                     environment: env,
                     payload: {
                       docker_tag: env === 'prod' ? 'v1.2.0' : 'v1.2.0-pre',
+                      repository_name: undefined,
                     },
                     production_environment: env === 'prod',
                     // TODO: test this more thoroughly


### PR DESCRIPTION
Jenkins job that gets triggered by deployment expects repository name to match application that is being deployed. Now, to allow releasing multiple applications from the same repo, we need to specify the application name in payload.

But, since deployment from a monorepo is only needed for applications and not all repositories are monorepo ones, we need to keep old behavior, that is why this payload defaults to repo name.