### PR TITLE
HPC-8676: Support multiple deployable apps per repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,18 +310,20 @@ this:
   "stagingEnvironmentBranch": "env/staging",
   "repoType": "node",
   "developmentEnvironmentBranches": [],
-  "docker": {
-    "path": "docker",
-    "args": {
+  "dockerImages": [
+    {
+      "dockerfilePath": "docker",
+      "args": {
         "commitSha": "COMMIT_SHA",
         "treeSha": "TREE_SHA"
-    },
+      },
       "environmentVariables": {
         "commitSha": "HPC_ACTIONS_COMMIT_SHA",
         "treeSha": "HPC_ACTIONS_TREE_SHA"
-    },
-    "repository": "dockerhub-org/repo",
-  },
+      },
+      "repository": "dockerhub-org/repo"
+    }
+  ],
   "ci": [],
   "mergebackLabels": ["mergeback"]
 }

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ must be followed:
     (either `env/stage` or `env/staging` as necessary).
   * Restart the workflow if necessary, this will:
     * Build the image with the new tag (with `-pre` appended),
-      and push it to DockerHub
+      and push it to AWS ECR
     * Run the CI / Unit Tests
     * Post a comment on the pull request when the workflow has finished successfully
   * Once the workflow is complete, merge the pull request, this will automatically:
@@ -211,7 +211,7 @@ and acts as a roadmap.
       * Run the docker build
       * Fetch the git tag to check the git tree hash has not been changed
         *(this will only happen with rapid concurrent pushes)*
-      * Push the image to DockerHub, using the version as the tag
+      * Push the image to AWS ECR, using the version as the tag
     * If there is
       * get the git tree sha that was used to build the image from the docker metadata
       * check that the git tree-sha of image matches the current tree-sha
@@ -226,7 +226,7 @@ and acts as a roadmap.
       (if the current branch is `env/<stage|staging>`).
 * Pushes to `env/<name>` (non-staging/production branches):
   * Run the docker build
-  * Push the image to DockerHub, using the name of the environment as a tag.
+  * Push the image to AWS ECR, using the name of the environment as a tag.
 * Pushes to `hotfix/<name>`:
   * Check if there is an open pull request for this branch:
     * If there is not: fail
@@ -244,7 +244,7 @@ and acts as a roadmap.
           on-top of the tracking branch.
       * Run CI Tasks (unit-tests etc…)
       * Run the docker build
-      * Push the image to DockerHub,
+      * Push the image to AWS ECR,
         using the version as the tag
         (regardless of whether the image already exists)
         * This allows us to deploy this image to a dev environment,
@@ -274,7 +274,7 @@ and acts as a roadmap.
             `develop` before branching off the `release/` branch).
       * Run CI Tasks (unit-tests etc…)
       * Run the docker build
-      * Push the image to DockerHub,
+      * Push the image to AWS ECR,
         using the version as the tag
         (regardless of whether the image already exists)
         * This allows us to deploy this image to a dev environment,
@@ -323,7 +323,7 @@ this:
         "commitSha": "HPC_ACTIONS_COMMIT_SHA",
         "treeSha": "HPC_ACTIONS_TREE_SHA"
       },
-      "repository": "dockerhub-org/repo"
+      "repository": "aws-ecr-org/repo"
     }
   ],
   "ci": [],

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ must be followed:
   * Update the version in `package.json` to match the new branch name.
   * Push this branch to GitHub.
   * Open a pull request that merges `release/<version>` into the staging branch
-    (either `env/stage` or `env/staging` as neccesary).
-  * Restart the workflow if neccesary, this will:
+    (either `env/stage` or `env/staging` as necessary).
+  * Restart the workflow if necessary, this will:
     * Build the image with the new tag (with `-pre` appended),
       and push it to DockerHub
     * Run the CI / Unit Tests
@@ -149,7 +149,7 @@ must be followed:
   * Once checks pass, merge the pull request, this will:
     * Create the tag / release on GitHub.
     * Trigger a build of the docker image in GitHub Actions
-      (if neccesary, usually not as it should reuse and retag the image on stage).
+      (if necessary, usually not as it should reuse and retag the image on stage).
     * Open a "mergeback" Pull Request, to merge the changes back into develop.
   * After the checks are complete:
     * deploy to the environment using the appropriate method.

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ this:
 
 ```json
 {
-  "stagingEnvironmentBranch": "env/staging",
+  "stagingEnvironmentBranch": "env/stage",
   "repoType": "node",
   "developmentEnvironmentBranches": [],
   "dockerImages": [

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The outlined workflow and actions are designed to:
   * Have a clear distinction between environment tracking,
     main development, hotfix and feature branches.
 * Allow us to know exactly what is deployed to each environment.
+  From monorepo repositories, multiple apps can be deployed simultaneously
 * Avoid pushing tags multiple times with different HEADs
 * Ensure that all changes have been given enough review,
   and pass unit-tests and code-quality checks before being deployed.
@@ -110,8 +111,8 @@ must be followed:
       git push -f origin env/blue.dev
       ```
 
-    * This will GitHub Actions to build and push the docker image,
-      and trigger the deployment automatically
+    * This will cause GitHub Actions to build and push the docker image
+      (or multiple Docker images in a monorepo), and trigger the deployment(s) automatically.
 
 * **Staging Environment:**
 
@@ -130,7 +131,7 @@ must be followed:
     * Run the CI / Unit Tests
     * Post a comment on the pull request when the workflow has finished successfully
   * Once the workflow is complete, merge the pull request, this will automatically:
-    * Trigger an automated deployment to the stage environment (if configured)
+    * Trigger an automated deployment(s) to the stage environment (if configured)
     * Open a "mergeback" Pull Request, to merge the changes back into `develop`.
       * Please approve and merge this pull request ASAP
     * (note that tags are not created when deploying to staging envs, only prod)
@@ -147,8 +148,8 @@ must be followed:
       and ensure that changes from `env/prod` are merged back into
       `env/<stage|staging>`, at which point the conflicts should be solved.
   * Once checks pass, merge the pull request, this will:
-    * Create the tag / release on GitHub.
-    * Trigger a build of the docker image in GitHub Actions
+    * Create the tag and release(s) (potentially multiple in a monorepo) on GitHub.
+    * Trigger a build of the docker image(s) in GitHub Actions
       (if necessary, usually not as it should reuse and retag the image on stage).
     * Open a "mergeback" Pull Request, to merge the changes back into develop.
   * After the checks are complete:
@@ -212,6 +213,7 @@ and acts as a roadmap.
       * Fetch the git tag to check the git tree hash has not been changed
         *(this will only happen with rapid concurrent pushes)*
       * Push the image to AWS ECR, using the version as the tag
+      * In monorepo, multiple images can be built and pushed to a remote Docker repository
     * If there is
       * get the git tree sha that was used to build the image from the docker metadata
       * check that the git tree-sha of image matches the current tree-sha
@@ -226,7 +228,8 @@ and acts as a roadmap.
       (if the current branch is `env/<stage|staging>`).
 * Pushes to `env/<name>` (non-staging/production branches):
   * Run the docker build
-  * Push the image to AWS ECR, using the name of the environment as a tag.
+  * Push the image to AWS ECR, using the name of the environment as a tag
+  * Do this for every app in a monorepo
 * Pushes to `hotfix/<name>`:
   * Check if there is an open pull request for this branch:
     * If there is not: fail
@@ -254,6 +257,7 @@ and acts as a roadmap.
           and the final deployment!
         * It also allows for updating the hotfixes with changes if it needs to
           be corrected.
+      * In monorepo, multiple images can be built and pushed to a remote Docker repository
 * Pushes to `release/<version>`:
   * Check if there is an open pull request for this branch:
     * If there is not: fail
@@ -284,6 +288,7 @@ and acts as a roadmap.
           and the final deployment!
         * It also allows for updating the release with changes if it needs to
           be corrected.
+      * In monorepo, multiple images can be built and pushed to a remote Docker repository
 * Pushes to `develop`:
   * Do nothing
 * Pushes to all other branches
@@ -312,8 +317,8 @@ this:
   "developmentEnvironmentBranches": [],
   "dockerImages": [
     {
-      "dockerfilePath": "docker",
-      "appName": "hpc-app",
+      "dockerfilePath": "docker-1",
+      "appName": "hpc-app-1",
       "args": {
         "commitSha": "COMMIT_SHA",
         "treeSha": "TREE_SHA",
@@ -323,7 +328,21 @@ this:
         "commitSha": "HPC_ACTIONS_COMMIT_SHA",
         "treeSha": "HPC_ACTIONS_TREE_SHA"
       },
-      "repository": "aws-ecr-org/repo"
+      "repository": "aws-ecr-org/repo-1"
+    },
+    {
+      "dockerfilePath": "docker-2",
+      "appName": "hpc-app-2",
+      "args": {
+        "commitSha": "COMMIT_SHA",
+        "treeSha": "TREE_SHA",
+        "appToBuild": "APP_TO_BUILD"
+      },
+      "environmentVariables": {
+        "commitSha": "HPC_ACTIONS_COMMIT_SHA",
+        "treeSha": "HPC_ACTIONS_TREE_SHA"
+      },
+      "repository": "aws-ecr-org/repo-2"
     }
   ],
   "ci": [],

--- a/README.md
+++ b/README.md
@@ -313,9 +313,11 @@ this:
   "dockerImages": [
     {
       "dockerfilePath": "docker",
+      "appName": "hpc-app",
       "args": {
         "commitSha": "COMMIT_SHA",
-        "treeSha": "TREE_SHA"
+        "treeSha": "TREE_SHA",
+        "appToBuild": "APP_TO_BUILD"
       },
       "environmentVariables": {
         "commitSha": "HPC_ACTIONS_COMMIT_SHA",
@@ -369,6 +371,7 @@ you need to also add the following lines to your `Dockerfile`:
 ```Dockerfile
 ARG COMMIT_SHA
 ARG TREE_SHA
+ARG APP_TO_BUILD # Optional
 ENV HPC_ACTIONS_COMMIT_SHA $COMMIT_SHA
 ENV HPC_ACTIONS_TREE_SHA $TREE_SHA
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: 'HPC Workflow'
 description: 'Action that implements the development workflow for HPC repos'
 author: 'Sam Lanning <sam@samlanning.com>'
+inputs:
+  apps-to-build:
+    description: 'Comma-separated list of applications to build'
+    required: false
 runs:
   using: 'node20'
   main: 'action/dist/index.js'

--- a/action/dist/index.js
+++ b/action/dist/index.js
@@ -42,6 +42,7 @@ const child_process_1 = __nccwpck_require__(3325);
 const config_1 = __nccwpck_require__(6816);
 const docker_1 = __nccwpck_require__(9610);
 const github_1 = __nccwpck_require__(5865);
+const util_1 = __nccwpck_require__(1238);
 const exec = (0, node_util_1.promisify)(child_process.exec);
 const GITHUB_ACTIONS_USER_ID = 41_898_282;
 const GITHUB_ACTIONS_USER_LOGIN = 'github-actions';
@@ -92,13 +93,15 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
     if (!env.GITHUB_REPOSITORY) {
         throw new Error('Expected GITHUB_REPOSITORY');
     }
-    // Get docker credentials
-    if (!config.docker.skipLogin) {
-        if (!env.DOCKER_USERNAME) {
-            throw new Error('Expected DOCKER_USERNAME');
-        }
-        if (!env.DOCKER_PASSWORD) {
-            throw new Error('Expected DOCKER_PASSWORD');
+    // Fail if there are no valid Docker credentials
+    for (const dockerConfig of config.dockerImages) {
+        if (!dockerConfig.skipLogin) {
+            if (!env.DOCKER_USERNAME) {
+                throw new Error('Expected DOCKER_USERNAME');
+            }
+            if (!env.DOCKER_PASSWORD) {
+                throw new Error('Expected DOCKER_PASSWORD');
+            }
         }
     }
     // Get GitHub credentials
@@ -119,6 +122,21 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
     else {
         throw new Error(`Unsupported GITHUB_EVENT_NAME: ${env.GITHUB_EVENT_NAME}`);
     }
+    const appsToBuild = env['INPUT_APPS-TO-BUILD']?.split(',').filter(Boolean);
+    // Check that `appsToBuild` param has valid values
+    const validApps = config.dockerImages.map((d) => d.appName).filter(util_1.isDefined);
+    if (appsToBuild?.length && !validApps.length) {
+        throw new Error('There are no valid apps to build');
+    }
+    for (const app of appsToBuild ?? []) {
+        if (!validApps.includes(app)) {
+            throw new Error(`Invalid name "${app}" provided as application name. ` +
+                `Valid application names are: ${validApps.join(', ')}`);
+        }
+    }
+    const imagesToBuild = config.dockerImages.filter((dockerConfig) => !dockerConfig.appName ||
+        !appsToBuild?.length ||
+        appsToBuild.includes(dockerConfig.appName));
     const github = gitHubInit({
         githubRepo: env.GITHUB_REPOSITORY,
         token: env.GITHUB_TOKEN,
@@ -196,9 +214,14 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
         }
         const head = await isomorphic_git_1.default.readCommit({ fs: node_fs_1.default, dir, oid: headShaAndVersion.sha });
         /**
-         * Return true if this is a pull request created by the GitHub Actions user,
-         * or dependabot, and so attempting to review the PR with the GitHub Actions
-         * token will fail, and commenting is required instead.
+         * For pull requests created by the GitHub Actions user, commenting is required,
+         * because attempting to review the PR with the GitHub Actions token would fail.
+         *
+         * Also, the `GITHUB_TOKEN` that is used for Dependabot actions has no write
+         * actions at all, which includes making comments on a PR. As a result, we can't
+         * comment at the end of a workflow that's started by Dependabot (e.g. PRs),
+         * so we just do nothing, and rely on the exit code being zero (i.e. the workflow
+         * succeeding) to allow for merges.
          */
         const commentMode = (pr) => pr.user?.id === UNOCHA_HPC_USER_ID ||
             pr.user?.id === GITHUB_ACTIONS_USER_ID ||
@@ -211,10 +234,11 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
                 ? 'none'
                 : 'review';
         const buildAndPushDockerImage = async (opts) => {
-            const { tag, checkBehaviour } = opts;
-            info('Logging in to docker');
-            const docker = dockerInit(config.docker);
-            if (!config.docker.skipLogin) {
+            const { dockerConfig, tag, checkBehaviour } = opts;
+            info('Initializing Docker controller');
+            const docker = dockerInit(dockerConfig);
+            if (!dockerConfig.skipLogin) {
+                info('Logging in to Docker');
                 if (!env.DOCKER_USERNAME || !env.DOCKER_PASSWORD) {
                     throw new Error('Unexpected error!');
                 }
@@ -224,7 +248,7 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
                 });
             }
             /**
-             * Set this to the image tag for any image we find that
+             * Set this to the image tag for any image we find
              * that was built with the same git tree.
              */
             let existingMatchingImage = null;
@@ -285,9 +309,10 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
             else {
                 await docker.runBuild({
                     tag,
-                    meta: {
+                    args: {
                         commitSha: head.oid,
                         treeSha: head.commit.tree,
+                        appToBuild: dockerConfig.appName,
                     },
                     cwd: dir,
                     logger,
@@ -336,11 +361,11 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
                 }
             }
             else {
-                info('Image built');
+                info(`Image built${dockerConfig.appName ? ` for app ${dockerConfig.appName}` : ''}`);
             }
-            info('Pushing image to docker repository');
+            info(`Pushing image to docker repository ${dockerConfig.repository}`);
             await docker.pushImage(tag);
-            info('Image Pushed');
+            info(`Image ${dockerConfig.repository}:${tag} pushed`);
         };
         const runCICommands = async () => {
             info('Running CI Checks');
@@ -430,9 +455,10 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
                 });
             }
         };
-        const buildAndPushDockerImageForReleaseOrHotfix = (params) => {
+        const buildAndPushDockerImageForReleaseOrHotfix = async (params) => {
             const { dockerTag, gitTag, pullRequest } = params;
-            return buildAndPushDockerImage({
+            await Promise.all(imagesToBuild.map((dockerConfig) => buildAndPushDockerImage({
+                dockerConfig,
                 checkBehaviour: null,
                 tag: dockerTag,
                 checkTag: {
@@ -441,21 +467,25 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
                     onError: () => failWithPRComment({
                         error: `Tag ${gitTag} has been created, aborting`,
                         pullRequest,
-                        comment: `During the build of the docker image, the tag ${dockerTag} ` +
+                        comment: `During the build of the docker image${dockerConfig.appName
+                            ? ` for app ${dockerConfig.appName}`
+                            : ''}, the tag ${dockerTag} ` +
                             'was created, and so the workflow has been aborted, ' +
                             'and the docker image has not been pushed.\n\n' +
-                            'Please chose a new version and update the pull request.',
+                            'Please choose a new version and update the pull request.',
                     }),
                 },
-            });
+            })));
         };
         const commentOnPullRequestWithDockerInfo = (params) => {
             const { pullRequest, tag } = params;
+            const deployedImages = imagesToBuild.map((dockerConfig) => dockerConfig.repository);
+            const isMultipleImages = deployedImages.length > 1;
             // Post about successful
-            const body = 'Docker image has been successfully built and pushed as: ' +
-                `\`${config.docker.repository}:${tag}\`\n\n` +
-                'Please deploy this image to a development environment, and test ' +
-                'it is working as expected before merging this pull request.';
+            const body = `Docker ${isMultipleImages ? 'images have' : 'image has'} been successfully built and pushed as: ` +
+                `${deployedImages.map((i) => `\`${i}:${tag}\``).join(', ')}\n\n` +
+                `Please deploy ${isMultipleImages ? 'these images' : 'this image'} to a development environment, and test ` +
+                `${isMultipleImages ? 'they are' : 'it is'} working as expected before merging this pull request.`;
             const cMode = commentMode(pullRequest);
             if (cMode === 'comment') {
                 return github.commentOnPullRequest({
@@ -482,6 +512,7 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
                             environment: environment.environment,
                             payload: {
                                 docker_tag: params.dockerTag,
+                                repository_name: params.repoName,
                             },
                             production_environment: mode === 'env-production',
                             transient_environment: false,
@@ -534,7 +565,8 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
                 }
                 deploymentSha = tagSha;
                 deploymentDockerTag = tag;
-                await buildAndPushDockerImage({
+                await Promise.all(imagesToBuild.map((dockerConfig) => buildAndPushDockerImage({
+                    dockerConfig,
                     checkBehaviour: {
                         checkStrict: true,
                         alsoCheck: [preTag],
@@ -545,10 +577,11 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
                         gitTag: tag,
                         sha: tagSha,
                     },
-                });
+                })));
             }
             else {
-                await buildAndPushDockerImage({
+                await Promise.all(imagesToBuild.map((dockerConfig) => buildAndPushDockerImage({
+                    dockerConfig,
                     checkBehaviour: {
                         checkStrict: false,
                         alsoCheck: [tag],
@@ -574,14 +607,15 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
                                 gitTag: tag,
                             },
                     },
-                });
+                })));
                 deploymentSha = head.oid;
                 deploymentDockerTag = preTag;
             }
-            await createDeploymentIfRequired({
+            await Promise.all(imagesToBuild.map((dockerConfig) => createDeploymentIfRequired({
                 dockerTag: deploymentDockerTag,
                 ref: deploymentSha,
-            });
+                repoName: dockerConfig.appName,
+            })));
             const mergebackBranch = `mergeback/${branch.substring(4)}/${version}`;
             info(`Creating and pushing mergeback Branch: ${mergebackBranch}`);
             await isomorphic_git_1.default.branch({ fs: node_fs_1.default, dir, ref: mergebackBranch });
@@ -598,14 +632,18 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
         }
         else if (mode === 'env-development') {
             const tag = branch.replaceAll('/', '-');
-            await buildAndPushDockerImage({
-                checkBehaviour: null,
-                tag,
-            });
-            await createDeploymentIfRequired({
-                dockerTag: tag,
-                ref: head.oid,
-            });
+            await Promise.all(imagesToBuild.map(async (dockerConfig) => {
+                await buildAndPushDockerImage({
+                    dockerConfig,
+                    checkBehaviour: null,
+                    tag,
+                });
+                await createDeploymentIfRequired({
+                    dockerTag: tag,
+                    ref: head.oid,
+                    repoName: dockerConfig.appName,
+                });
+            }));
         }
         else if (mode === 'hotfix') {
             const pullRequest = await getUniquePullRequest();
@@ -792,21 +830,29 @@ const DOCKER_CONFIG = t.intersection([
         /**
          * Where in the repository should the build be run from
          */
-        path: t.string,
+        dockerfilePath: t.string,
         /**
          * What are the names of the build arguments that the docker image
          * expects to be supplied
          */
-        args: t.type({
-            /**
-             * What is the name of the build argument that expects the commit sha
-             */
-            commitSha: t.string,
-            /**
-             * What is the name of the build argument that expects the tree sha
-             */
-            treeSha: t.string,
-        }),
+        args: t.intersection([
+            t.type({
+                /**
+                 * What is the name of the build argument that expects the commit sha
+                 */
+                commitSha: t.string,
+                /**
+                 * What is the name of the build argument that expects the tree sha
+                 */
+                treeSha: t.string,
+            }),
+            t.partial({
+                /**
+                 * What is the name of the build argument used to specify application to build.
+                 */
+                appToBuild: t.string,
+            }),
+        ]),
         /**
          * What are the names of the environment variables where important bits of
          * information are stored
@@ -828,6 +874,10 @@ const DOCKER_CONFIG = t.intersection([
     }),
     // Optional config
     t.partial({
+        /**
+         * Name of the application
+         */
+        appName: t.string,
         /**
          * If provided, use the given registry instead of Docker Hub.
          *
@@ -868,9 +918,9 @@ const CONFIG = t.intersection([
             node: null,
         }),
         /**
-         * Configuration for the docker image build and publication
+         * Configuration for the docker images to be built and published
          */
-        docker: DOCKER_CONFIG,
+        dockerImages: t.array(DOCKER_CONFIG),
     }),
     // Optional config
     t.partial({
@@ -931,10 +981,12 @@ const getConfig = async (env) => {
             throw new Error('Invalid Configuration: All development environment branches must start with env/');
         }
     }
-    if (config.right.docker.registry &&
-        !config.right.docker.repository.startsWith(`${config.right.docker.registry}/`)) {
-        throw new Error('Invalid Configuration: Docker repository must start with: ' +
-            `${config.right.docker.registry}/`);
+    for (const dockerConfig of config.right.dockerImages) {
+        if (dockerConfig.registry &&
+            !dockerConfig.repository.startsWith(`${dockerConfig.registry}/`)) {
+            throw new Error('Invalid Configuration: Docker repository must start with: ' +
+                `${dockerConfig.registry}/`);
+        }
     }
     return config.right;
 };
@@ -1034,11 +1086,14 @@ const REAL_DOCKER = (config) => ({
             treeSha,
         };
     },
-    runBuild: async ({ cwd, tag, meta, logger }) => {
+    runBuild: async ({ cwd, tag, args, logger }) => {
         await (0, child_process_1.execAndPipeOutput)({
-            command: `docker build ${config.path} ` +
-                `--build-arg ${config.args.commitSha}=${meta.commitSha} ` +
-                `--build-arg ${config.args.treeSha}=${meta.treeSha} ` +
+            command: `docker build ${config.dockerfilePath} ` +
+                `--build-arg ${config.args.commitSha}=${args.commitSha} ` +
+                `--build-arg ${config.args.treeSha}=${args.treeSha} ` +
+                `${config.args.appToBuild
+                    ? `--build-arg ${config.args.appToBuild}=${args.appToBuild} `
+                    : ''}` +
                 `-t ${config.repository}:${tag}`,
             logger,
             cwd,
@@ -1218,6 +1273,19 @@ const execAndPipeOutput = (opts) => {
 };
 exports.execAndPipeOutput = execAndPipeOutput;
 exports.exec = (0, node_util_1.promisify)(child_process.exec);
+
+
+/***/ }),
+
+/***/ 1238:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.isDefined = void 0;
+const isDefined = (v) => v !== null && v !== undefined;
+exports.isDefined = isDefined;
 
 
 /***/ }),

--- a/action/src/action.ts
+++ b/action/src/action.ts
@@ -351,9 +351,10 @@ export const runAction = async ({
           };
     }) => {
       const { dockerConfig, tag, checkBehaviour } = opts;
-      info('Logging in to docker');
+      info('Initializing Docker controller');
       const docker = dockerInit(dockerConfig);
       if (!dockerConfig.skipLogin) {
+        info('Logging in to Docker');
         if (!env.DOCKER_USERNAME || !env.DOCKER_PASSWORD) {
           throw new Error('Unexpected error!');
         }

--- a/action/src/action.ts
+++ b/action/src/action.ts
@@ -483,11 +483,15 @@ export const runAction = async ({
           info('Tag has not been created, okay to continue');
         }
       } else {
-        info('Image built');
+        info(
+          `Image built${
+            dockerConfig.appName ? ` for app ${dockerConfig.appName}` : ''
+          }`
+        );
       }
-      info('Pushing image to docker repository');
+      info(`Pushing image to docker repository ${dockerConfig.repository}`);
       await docker.pushImage(tag);
-      info('Image Pushed');
+      info(`Image ${dockerConfig.repository}:${tag} pushed`);
     };
 
     const runCICommands = async () => {

--- a/action/src/action.ts
+++ b/action/src/action.ts
@@ -239,9 +239,14 @@ export const runAction = async ({
     const head = await git.readCommit({ fs, dir, oid: headShaAndVersion.sha });
 
     /**
-     * Return true if this is a pull request created by the GitHub Actions user,
-     * or dependabot, and so attempting to review the PR with the GitHub Actions
-     * token will fail, and commenting is required instead.
+     * For pull requests created by the GitHub Actions user, commenting is required,
+     * because attempting to review the PR with the GitHub Actions token would fail.
+     *
+     * Also, the `GITHUB_TOKEN` that is used for Dependabot actions has no write
+     * actions at all, which includes making comments on a PR. As a result, we can't
+     * comment at the end of a workflow that's started by Dependabot (e.g. PRs),
+     * so we just do nothing, and rely on the exit code being zero (i.e. the workflow
+     * succeeding) to allow for merges.
      */
     const commentMode = (pr: PullRequest): 'review' | 'comment' | 'none' =>
       pr.user?.id === UNOCHA_HPC_USER_ID ||

--- a/action/src/action.ts
+++ b/action/src/action.ts
@@ -648,12 +648,24 @@ export const runAction = async ({
       tag: string;
     }) => {
       const { pullRequest, tag } = params;
+
+      const deployedImages = imagesToBuild.map(
+        (dockerConfig) => dockerConfig.repository
+      );
+      const isMultipleImages = deployedImages.length > 1;
+
       // Post about successful
       const body =
-        'Docker image has been successfully built and pushed as: ' +
-        `\`${config.docker.repository}:${tag}\`\n\n` +
-        'Please deploy this image to a development environment, and test ' +
-        'it is working as expected before merging this pull request.';
+        `Docker ${
+          isMultipleImages ? 'images have' : 'image has'
+        } been successfully built and pushed as: ` +
+        `${deployedImages.map((i) => `\`${i}:${tag}\``).join(', ')}\n\n` +
+        `Please deploy ${
+          isMultipleImages ? 'these images' : 'this image'
+        } to a development environment, and test ` +
+        `${
+          isMultipleImages ? 'they are' : 'it is'
+        } working as expected before merging this pull request.`;
       const cMode = commentMode(pullRequest);
       if (cMode === 'comment') {
         return github.commentOnPullRequest({

--- a/action/src/action.ts
+++ b/action/src/action.ts
@@ -6,7 +6,7 @@ import { promisify } from 'node:util';
 
 import { execAndPipeOutput } from './util/child_process';
 
-import { getConfig, type Config, type Env } from './config';
+import { getConfig, type Config, type DockerConfig, type Env } from './config';
 import { REAL_DOCKER, type DockerInit } from './docker';
 import { REAL_GITHUB, type GitHubInit, type PullRequest } from './github';
 
@@ -108,13 +108,15 @@ export const runAction = async ({
     throw new Error('Expected GITHUB_REPOSITORY');
   }
 
-  // Get docker credentials
-  if (!config.docker.skipLogin) {
-    if (!env.DOCKER_USERNAME) {
-      throw new Error('Expected DOCKER_USERNAME');
-    }
-    if (!env.DOCKER_PASSWORD) {
-      throw new Error('Expected DOCKER_PASSWORD');
+  // Fail if there are no valid Docker credentials
+  for (const dockerConfig of config.dockerImages) {
+    if (!dockerConfig.skipLogin) {
+      if (!env.DOCKER_USERNAME) {
+        throw new Error('Expected DOCKER_USERNAME');
+      }
+      if (!env.DOCKER_PASSWORD) {
+        throw new Error('Expected DOCKER_PASSWORD');
+      }
     }
   }
 
@@ -278,6 +280,7 @@ export const runAction = async ({
         };
 
     const buildAndPushDockerImage = async (opts: {
+      dockerConfig: DockerConfig;
       checkBehaviour: null | {
         /**
          * If checkStrict is true,
@@ -322,10 +325,10 @@ export const runAction = async ({
             built: BuildAndPushDockerImageCheckTagCondition;
           };
     }) => {
-      const { tag, checkBehaviour } = opts;
+      const { dockerConfig, tag, checkBehaviour } = opts;
       info('Logging in to docker');
-      const docker = dockerInit(config.docker);
-      if (!config.docker.skipLogin) {
+      const docker = dockerInit(dockerConfig);
+      if (!dockerConfig.skipLogin) {
         if (!env.DOCKER_USERNAME || !env.DOCKER_PASSWORD) {
           throw new Error('Unexpected error!');
         }
@@ -572,7 +575,7 @@ export const runAction = async ({
       }
     };
 
-    const buildAndPushDockerImageForReleaseOrHotfix = (params: {
+    const buildAndPushDockerImageForReleaseOrHotfix = async (params: {
       /**
        * The docker tag to use
        */
@@ -585,24 +588,29 @@ export const runAction = async ({
     }) => {
       const { dockerTag, gitTag, pullRequest } = params;
 
-      return buildAndPushDockerImage({
-        checkBehaviour: null,
-        tag: dockerTag,
-        checkTag: {
-          mode: 'non-existant',
-          gitTag,
-          onError: () =>
-            failWithPRComment({
-              error: `Tag ${gitTag} has been created, aborting`,
-              pullRequest,
-              comment:
-                `During the build of the docker image, the tag ${dockerTag} ` +
-                'was created, and so the workflow has been aborted, ' +
-                'and the docker image has not been pushed.\n\n' +
-                'Please chose a new version and update the pull request.',
-            }),
-        },
-      });
+      await Promise.all(
+        config.dockerImages.map((dockerConfig) =>
+          buildAndPushDockerImage({
+            dockerConfig,
+            checkBehaviour: null,
+            tag: dockerTag,
+            checkTag: {
+              mode: 'non-existant',
+              gitTag,
+              onError: () =>
+                failWithPRComment({
+                  error: `Tag ${gitTag} has been created, aborting`,
+                  pullRequest,
+                  comment:
+                    `During the build of the docker image, the tag ${dockerTag} ` +
+                    'was created, and so the workflow has been aborted, ' +
+                    'and the docker image has not been pushed.\n\n' +
+                    'Please choose a new version and update the pull request.',
+                }),
+            },
+          })
+        )
+      );
     };
 
     const commentOnPullRequestWithDockerInfo = (params: {
@@ -701,54 +709,70 @@ export const runAction = async ({
         }
         deploymentSha = tagSha;
         deploymentDockerTag = tag;
-        await buildAndPushDockerImage({
-          checkBehaviour: {
-            checkStrict: true,
-            alsoCheck: [preTag],
-          },
-          tag,
-          checkTag: {
-            mode: 'match',
-            gitTag: tag,
-            sha: tagSha,
-          },
-        });
+
+        await Promise.all(
+          config.dockerImages.map((dockerConfig) =>
+            buildAndPushDockerImage({
+              dockerConfig,
+              checkBehaviour: {
+                checkStrict: true,
+                alsoCheck: [preTag],
+              },
+              tag,
+              checkTag: {
+                mode: 'match',
+                gitTag: tag,
+                sha: tagSha,
+              },
+            })
+          )
+        );
       } else {
-        await buildAndPushDockerImage({
-          checkBehaviour: {
-            checkStrict: false,
-            alsoCheck: [tag],
-          },
-          tag: preTag,
-          checkTag: {
-            mode: 'conditional',
-            built: {
-              mode: 'non-existant',
-              gitTag: tag,
-            },
-            // If an image is retagged, and we know about an existing git tag
-            // then ensure that the git tag is still the same,
-            // otherwise require that it doesn't exist
-            retagged: tagSha
-              ? {
-                  mode: 'match',
-                  gitTag: tag,
-                  sha: tagSha,
-                }
-              : {
+        await Promise.all(
+          config.dockerImages.map((dockerConfig) =>
+            buildAndPushDockerImage({
+              dockerConfig,
+              checkBehaviour: {
+                checkStrict: false,
+                alsoCheck: [tag],
+              },
+              tag: preTag,
+              checkTag: {
+                mode: 'conditional',
+                built: {
                   mode: 'non-existant',
                   gitTag: tag,
                 },
-          },
-        });
+                // If an image is retagged, and we know about an existing git tag
+                // then ensure that the git tag is still the same,
+                // otherwise require that it doesn't exist
+                retagged: tagSha
+                  ? {
+                      mode: 'match',
+                      gitTag: tag,
+                      sha: tagSha,
+                    }
+                  : {
+                      mode: 'non-existant',
+                      gitTag: tag,
+                    },
+              },
+            })
+          )
+        );
+
         deploymentSha = head.oid;
         deploymentDockerTag = preTag;
       }
 
-      await createDeploymentIfRequired({
-        dockerTag: deploymentDockerTag,
-        ref: deploymentSha,
-      });
+      await Promise.all(
+        config.dockerImages.map(() =>
+          createDeploymentIfRequired({
+            dockerTag: deploymentDockerTag,
+            ref: deploymentSha,
+          })
+        )
+      );
 
       const mergebackBranch = `mergeback/${branch.substring(4)}/${version}`;
       info(`Creating and pushing mergeback Branch: ${mergebackBranch}`);
@@ -768,14 +792,20 @@ export const runAction = async ({
       info('Pull Request Opened, workflow complete');
     } else if (mode === 'env-development') {
       const tag = branch.replaceAll('/', '-');
-      await buildAndPushDockerImage({
-        checkBehaviour: null,
-        tag,
-      });
-      await createDeploymentIfRequired({
-        dockerTag: tag,
-        ref: head.oid,
-      });
+
+      await Promise.all(
+        config.dockerImages.map(async (dockerConfig) => {
+          await buildAndPushDockerImage({
+            dockerConfig,
+            checkBehaviour: null,
+            tag,
+          });
+          await createDeploymentIfRequired({
+            dockerTag: tag,
+            ref: head.oid,
+          });
+        })
+      );
     } else if (mode === 'hotfix') {
       const pullRequest = await getUniquePullRequest();
 

--- a/action/src/action.ts
+++ b/action/src/action.ts
@@ -399,7 +399,7 @@ export const runAction = async ({
       } else {
         await docker.runBuild({
           tag,
-          meta: {
+          args: {
             commitSha: head.oid,
             treeSha: head.commit.tree,
           },

--- a/action/src/action.ts
+++ b/action/src/action.ts
@@ -331,7 +331,7 @@ export const runAction = async ({
       }
 
       /**
-       * Set this to the image tag for any image we find that
+       * Set this to the image tag for any image we find
        * that was built with the same git tree.
        */
       let existingMatchingImage: string | null = null;

--- a/action/src/action.ts
+++ b/action/src/action.ts
@@ -684,6 +684,7 @@ export const runAction = async ({
     const createDeploymentIfRequired = async (params: {
       dockerTag: string;
       ref: string;
+      repoName?: string;
     }) => {
       if (config.deployments) {
         for (const environment of config.deployments.environments) {
@@ -695,6 +696,7 @@ export const runAction = async ({
               environment: environment.environment,
               payload: {
                 docker_tag: params.dockerTag,
+                repository_name: params.repoName,
               },
               production_environment: mode === 'env-production',
               transient_environment: false,
@@ -808,10 +810,11 @@ export const runAction = async ({
       }
 
       await Promise.all(
-        imagesToBuild.map(() =>
+        imagesToBuild.map((dockerConfig) =>
           createDeploymentIfRequired({
             dockerTag: deploymentDockerTag,
             ref: deploymentSha,
+            repoName: dockerConfig.appName,
           })
         )
       );
@@ -845,6 +848,7 @@ export const runAction = async ({
           await createDeploymentIfRequired({
             dockerTag: tag,
             ref: head.oid,
+            repoName: dockerConfig.appName,
           });
         })
       );

--- a/action/src/action.ts
+++ b/action/src/action.ts
@@ -9,6 +9,7 @@ import { execAndPipeOutput } from './util/child_process';
 import { getConfig, type Config, type DockerConfig, type Env } from './config';
 import { REAL_DOCKER, type DockerInit } from './docker';
 import { REAL_GITHUB, type GitHubInit, type PullRequest } from './github';
+import { isDefined } from './util';
 
 const exec = promisify(child_process.exec);
 
@@ -141,6 +142,30 @@ export const runAction = async ({
   } else {
     throw new Error(`Unsupported GITHUB_EVENT_NAME: ${env.GITHUB_EVENT_NAME}`);
   }
+
+  const appsToBuild = env['INPUT_APPS-TO-BUILD']?.split(',').filter(Boolean);
+
+  // Check that `appsToBuild` param has valid values
+
+  const validApps = config.dockerImages.map((d) => d.appName).filter(isDefined);
+  if (appsToBuild?.length && !validApps.length) {
+    throw new Error('There are no valid apps to build');
+  }
+  for (const app of appsToBuild ?? []) {
+    if (!validApps.includes(app)) {
+      throw new Error(
+        `Invalid name "${app}" provided as application name. ` +
+          `Valid application names are: ${validApps.join(', ')}`
+      );
+    }
+  }
+
+  const imagesToBuild = config.dockerImages.filter(
+    (dockerConfig) =>
+      !dockerConfig.appName ||
+      !appsToBuild?.length ||
+      appsToBuild.includes(dockerConfig.appName)
+  );
 
   const github = gitHubInit({
     githubRepo: env.GITHUB_REPOSITORY,
@@ -410,6 +435,7 @@ export const runAction = async ({
           args: {
             commitSha: head.oid,
             treeSha: head.commit.tree,
+            appToBuild: dockerConfig.appName,
           },
           cwd: dir,
           logger,
@@ -589,7 +615,7 @@ export const runAction = async ({
       const { dockerTag, gitTag, pullRequest } = params;
 
       await Promise.all(
-        config.dockerImages.map((dockerConfig) =>
+        imagesToBuild.map((dockerConfig) =>
           buildAndPushDockerImage({
             dockerConfig,
             checkBehaviour: null,
@@ -602,7 +628,11 @@ export const runAction = async ({
                   error: `Tag ${gitTag} has been created, aborting`,
                   pullRequest,
                   comment:
-                    `During the build of the docker image, the tag ${dockerTag} ` +
+                    `During the build of the docker image${
+                      dockerConfig.appName
+                        ? ` for app ${dockerConfig.appName}`
+                        : ''
+                    }, the tag ${dockerTag} ` +
                     'was created, and so the workflow has been aborted, ' +
                     'and the docker image has not been pushed.\n\n' +
                     'Please choose a new version and update the pull request.',
@@ -711,7 +741,7 @@ export const runAction = async ({
         deploymentDockerTag = tag;
 
         await Promise.all(
-          config.dockerImages.map((dockerConfig) =>
+          imagesToBuild.map((dockerConfig) =>
             buildAndPushDockerImage({
               dockerConfig,
               checkBehaviour: {
@@ -729,7 +759,7 @@ export const runAction = async ({
         );
       } else {
         await Promise.all(
-          config.dockerImages.map((dockerConfig) =>
+          imagesToBuild.map((dockerConfig) =>
             buildAndPushDockerImage({
               dockerConfig,
               checkBehaviour: {
@@ -766,7 +796,7 @@ export const runAction = async ({
       }
 
       await Promise.all(
-        config.dockerImages.map(() =>
+        imagesToBuild.map(() =>
           createDeploymentIfRequired({
             dockerTag: deploymentDockerTag,
             ref: deploymentSha,
@@ -794,7 +824,7 @@ export const runAction = async ({
       const tag = branch.replaceAll('/', '-');
 
       await Promise.all(
-        config.dockerImages.map(async (dockerConfig) => {
+        imagesToBuild.map(async (dockerConfig) => {
           await buildAndPushDockerImage({
             dockerConfig,
             checkBehaviour: null,

--- a/action/src/config.ts
+++ b/action/src/config.ts
@@ -33,6 +33,14 @@ export interface Env {
    * Token to use when interacting with the GitHub API
    */
   GITHUB_TOKEN?: string;
+  /**
+   * Environment variable coming from "apps-to-build" `inputs` argument
+   * of this action. When you specify an input in a workflow file or use a
+   * default input value, GitHub creates an environment variable for the input
+   * with the name `INPUT_<VARIABLE_NAME>`. The environment variable created
+   * converts input names to uppercase letters and replaces spaces with `_` characters.
+   */
+  'INPUT_APPS-TO-BUILD'?: string;
 
   // Implicit environment variables passed by GitHub
   GITHUB_REPOSITORY?: string;
@@ -95,6 +103,10 @@ const DOCKER_CONFIG = t.intersection([
   }),
   // Optional config
   t.partial({
+    /**
+     * Name of the application
+     */
+    appName: t.string,
     /**
      * If provided, use the given registry instead of Docker Hub.
      *

--- a/action/src/config.ts
+++ b/action/src/config.ts
@@ -56,16 +56,24 @@ const DOCKER_CONFIG = t.intersection([
      * What are the names of the build arguments that the docker image
      * expects to be supplied
      */
-    args: t.type({
-      /**
-       * What is the name of the build argument that expects the commit sha
-       */
-      commitSha: t.string,
-      /**
-       * What is the name of the build argument that expects the tree sha
-       */
-      treeSha: t.string,
-    }),
+    args: t.intersection([
+      t.type({
+        /**
+         * What is the name of the build argument that expects the commit sha
+         */
+        commitSha: t.string,
+        /**
+         * What is the name of the build argument that expects the tree sha
+         */
+        treeSha: t.string,
+      }),
+      t.partial({
+        /**
+         * What is the name of the build argument used to specify application to build.
+         */
+        appToBuild: t.string,
+      }),
+    ]),
     /**
      * What are the names of the environment variables where important bits of
      * information are stored

--- a/action/src/config.ts
+++ b/action/src/config.ts
@@ -51,7 +51,7 @@ const DOCKER_CONFIG = t.intersection([
     /**
      * Where in the repository should the build be run from
      */
-    path: t.string,
+    dockerfilePath: t.string,
     /**
      * What are the names of the build arguments that the docker image
      * expects to be supplied
@@ -136,9 +136,9 @@ const CONFIG = t.intersection([
       node: null,
     }),
     /**
-     * Configuration for the docker image build and publication
+     * Configuration for the docker images to be built and published
      */
-    docker: DOCKER_CONFIG,
+    dockerImages: t.array(DOCKER_CONFIG),
   }),
   // Optional config
   t.partial({
@@ -216,16 +216,18 @@ export const getConfig = async (env: Env): Promise<Config> => {
       );
     }
   }
-  if (
-    config.right.docker.registry &&
-    !config.right.docker.repository.startsWith(
-      `${config.right.docker.registry}/`
-    )
-  ) {
-    throw new Error(
-      'Invalid Configuration: Docker repository must start with: ' +
-        `${config.right.docker.registry}/`
-    );
+
+  for (const dockerConfig of config.right.dockerImages) {
+    if (
+      dockerConfig.registry &&
+      !dockerConfig.repository.startsWith(`${dockerConfig.registry}/`)
+    ) {
+      throw new Error(
+        'Invalid Configuration: Docker repository must start with: ' +
+          `${dockerConfig.registry}/`
+      );
+    }
   }
+
   return config.right;
 };

--- a/action/src/config.ts
+++ b/action/src/config.ts
@@ -18,7 +18,7 @@ import { promises as fs } from 'node:fs';
 export interface Env {
   /**
    * The path to the configuration json file,
-   * that adheres to the specification set out by CONFIG above.
+   * that adheres to the specification set out by CONFIG below.
    */
   CONFIG_FILE?: string;
   /**

--- a/action/src/docker.ts
+++ b/action/src/docker.ts
@@ -9,9 +9,13 @@ import { type DockerConfig } from './config';
 
 export type DockerInit = (config: DockerConfig) => DockerController;
 
-export interface DockerImageMetadata {
+interface DockerImageMetadata {
   commitSha: string;
   treeSha: string;
+}
+
+export interface DockerImageBuildArgs extends DockerImageMetadata {
+  appToBuild?: string;
 }
 
 export interface DockerController {
@@ -31,7 +35,7 @@ export interface DockerController {
   runBuild: (opts: {
     cwd: string;
     tag: string;
-    meta: DockerImageMetadata;
+    args: DockerImageBuildArgs;
     logger: Logger;
   }) => Promise<void>;
   /**
@@ -118,12 +122,17 @@ export const REAL_DOCKER: DockerInit = (config) => ({
     };
   },
 
-  runBuild: async ({ cwd, tag, meta, logger }) => {
+  runBuild: async ({ cwd, tag, args, logger }) => {
     await execAndPipeOutput({
       command:
         `docker build ${config.path} ` +
-        `--build-arg ${config.args.commitSha}=${meta.commitSha} ` +
-        `--build-arg ${config.args.treeSha}=${meta.treeSha} ` +
+        `--build-arg ${config.args.commitSha}=${args.commitSha} ` +
+        `--build-arg ${config.args.treeSha}=${args.treeSha} ` +
+        `${
+          config.args.appToBuild
+            ? `--build-arg ${config.args.appToBuild}=${args.appToBuild} `
+            : ''
+        }` +
         `-t ${config.repository}:${tag}`,
       logger,
       cwd,

--- a/action/src/docker.ts
+++ b/action/src/docker.ts
@@ -125,7 +125,7 @@ export const REAL_DOCKER: DockerInit = (config) => ({
   runBuild: async ({ cwd, tag, args, logger }) => {
     await execAndPipeOutput({
       command:
-        `docker build ${config.path} ` +
+        `docker build ${config.dockerfilePath} ` +
         `--build-arg ${config.args.commitSha}=${args.commitSha} ` +
         `--build-arg ${config.args.treeSha}=${args.treeSha} ` +
         `${

--- a/action/src/util/index.ts
+++ b/action/src/util/index.ts
@@ -1,0 +1,2 @@
+export const isDefined = <T>(v: T | null | undefined): v is T =>
+  v !== null && v !== undefined;

--- a/action/test/specs/__snapshots__/action.spec.ts.snap
+++ b/action/test/specs/__snapshots__/action.spec.ts.snap
@@ -22,7 +22,10 @@ exports[`action runAction push to env/<dev> branch Valid Push and Build 1`] = `
     "##[info] Handling push to branch env/dev",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Skipping check for existing image with tag env-dev, building new image",
@@ -31,10 +34,10 @@ exports[`action runAction push to env/<dev> branch Valid Push and Build 1`] = `
     "##[info] Image built",
   ],
   [
-    "##[info] Pushing image to docker repository",
+    "##[info] Pushing image to docker repository hpc-actions/unit-test",
   ],
   [
-    "##[info] Image Pushed",
+    "##[info] Image hpc-actions/unit-test:env-dev pushed",
   ],
 ]
 `;
@@ -117,7 +120,10 @@ exports[`action runAction push to hotfix/<name> branch Successful hotfix (self) 
     "##[info] Checking if there is an existing tag for v1.2.1",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Skipping check for existing image with tag v1.2.1-pre, building new image",
@@ -129,10 +135,10 @@ exports[`action runAction push to hotfix/<name> branch Successful hotfix (self) 
     "##[info] Tag has not been created, okay to continue",
   ],
   [
-    "##[info] Pushing image to docker repository",
+    "##[info] Pushing image to docker repository hpc-actions/unit-test",
   ],
   [
-    "##[info] Image Pushed",
+    "##[info] Image hpc-actions/unit-test:v1.2.1-pre pushed",
   ],
   [
     "##[info] Running CI Checks",
@@ -157,7 +163,7 @@ exports[`action runAction push to hotfix/<name> branch Successful hotfix (self) 
 [
   [
     {
-      "body": "Docker image has been successfully built and pushed as: \`:v1.2.1-pre\`
+      "body": "Docker image has been successfully built and pushed as: \`hpc-actions/unit-test:v1.2.1-pre\`
 
 Please deploy this image to a development environment, and test it is working as expected before merging this pull request.",
       "pullRequestNumber": 321,
@@ -188,7 +194,10 @@ exports[`action runAction push to hotfix/<name> branch Successful hotfix 1`] = `
     "##[info] Checking if there is an existing tag for v1.2.1",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Skipping check for existing image with tag v1.2.1-pre, building new image",
@@ -200,10 +209,10 @@ exports[`action runAction push to hotfix/<name> branch Successful hotfix 1`] = `
     "##[info] Tag has not been created, okay to continue",
   ],
   [
-    "##[info] Pushing image to docker repository",
+    "##[info] Pushing image to docker repository hpc-actions/unit-test",
   ],
   [
-    "##[info] Image Pushed",
+    "##[info] Image hpc-actions/unit-test:v1.2.1-pre pushed",
   ],
   [
     "##[info] Running CI Checks",
@@ -228,7 +237,7 @@ exports[`action runAction push to hotfix/<name> branch Successful hotfix 3`] = `
 [
   [
     {
-      "body": "Docker image has been successfully built and pushed as: \`:v1.2.1-pre\`
+      "body": "Docker image has been successfully built and pushed as: \`hpc-actions/unit-test:v1.2.1-pre\`
 
 Please deploy this image to a development environment, and test it is working as expected before merging this pull request.",
       "pullRequestNumber": 321,
@@ -297,7 +306,10 @@ exports[`action runAction push to hotfix/<name> branch Tag created during build 
     "##[info] Checking if there is an existing tag for v1.2.1",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Skipping check for existing image with tag v1.2.1-pre, building new image",
@@ -324,7 +336,7 @@ exports[`action runAction push to hotfix/<name> branch Tag created during build 
     {
       "body": "During the build of the docker image, the tag v1.2.1-pre was created, and so the workflow has been aborted, and the docker image has not been pushed.
 
-Please chose a new version and update the pull request.",
+Please choose a new version and update the pull request.",
       "pullRequestNumber": 321,
       "state": "reject",
     },
@@ -685,7 +697,10 @@ exports[`action runAction push to production or staging env/prod deployments + m
     "##[info] Creating and pushing new tag v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0",
@@ -709,10 +724,10 @@ exports[`action runAction push to production or staging env/prod deployments + m
     "##[info] Tag is unchanged, okay to continue",
   ],
   [
-    "##[info] Pushing image to docker repository",
+    "##[info] Pushing image to docker repository hpc-actions/unit-test",
   ],
   [
-    "##[info] Image Pushed",
+    "##[info] Image hpc-actions/unit-test:v1.2.0 pushed",
   ],
   [
     "##[info] Creating prod deployment",
@@ -756,7 +771,10 @@ exports[`action runAction push to production or staging env/prod deployments + m
     "##[info] Creating and pushing new tag v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0",
@@ -780,10 +798,10 @@ exports[`action runAction push to production or staging env/prod deployments + m
     "##[info] Tag is unchanged, okay to continue",
   ],
   [
-    "##[info] Pushing image to docker repository",
+    "##[info] Pushing image to docker repository hpc-actions/unit-test",
   ],
   [
-    "##[info] Image Pushed",
+    "##[info] Image hpc-actions/unit-test:v1.2.0 pushed",
   ],
   [
     "##[info] Creating and pushing mergeback Branch: mergeback/prod/1.2.0",
@@ -824,7 +842,10 @@ exports[`action runAction push to production or staging env/prod docker Existing
     "##[info] Creating and pushing new tag v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0",
@@ -866,7 +887,10 @@ exports[`action runAction push to production or staging env/prod docker Existing
     "##[info] The tag is for the current commit, okay to continue",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0",
@@ -916,7 +940,10 @@ exports[`action runAction push to production or staging env/prod docker Existing
     "##[info] Creating and pushing new tag v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0",
@@ -966,7 +993,10 @@ exports[`action runAction push to production or staging env/prod docker Existing
     "##[info] Creating and pushing new tag v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0",
@@ -1023,7 +1053,10 @@ exports[`action runAction push to production or staging env/prod docker Existing
     "##[info] Creating and pushing new tag v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0",
@@ -1080,7 +1113,10 @@ exports[`action runAction push to production or staging env/prod docker Non-Exis
     "##[info] Creating and pushing new tag v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0",
@@ -1131,7 +1167,10 @@ exports[`action runAction push to production or staging env/prod docker Non-Exis
     "##[info] Creating and pushing new tag v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0",
@@ -1155,10 +1194,10 @@ exports[`action runAction push to production or staging env/prod docker Non-Exis
     "##[info] Tag is unchanged, okay to continue",
   ],
   [
-    "##[info] Pushing image to docker repository",
+    "##[info] Pushing image to docker repository hpc-actions/unit-test",
   ],
   [
-    "##[info] Image Pushed",
+    "##[info] Image hpc-actions/unit-test:v1.2.0 pushed",
   ],
   [
     "##[info] Creating and pushing mergeback Branch: mergeback/prod/1.2.0",
@@ -1201,7 +1240,10 @@ exports[`action runAction push to production or staging env/prod mergeback 1`] =
     "##[info] Creating and pushing new tag v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0",
@@ -1225,10 +1267,10 @@ exports[`action runAction push to production or staging env/prod mergeback 1`] =
     "##[info] Tag is unchanged, okay to continue",
   ],
   [
-    "##[info] Pushing image to docker repository",
+    "##[info] Pushing image to docker repository hpc-actions/unit-test",
   ],
   [
-    "##[info] Image Pushed",
+    "##[info] Image hpc-actions/unit-test:v1.2.0 pushed",
   ],
   [
     "##[info] Creating and pushing mergeback Branch: mergeback/prod/1.2.0",
@@ -1286,7 +1328,10 @@ exports[`action runAction push to production or staging env/prod tagging Existin
     "##[info] The tag is for the current commit, okay to continue",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0",
@@ -1309,7 +1354,10 @@ exports[`action runAction push to production or staging env/prod tagging Existin
     "##[info] The current tree matches the existing tag, okay to continue",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0",
@@ -1329,7 +1377,10 @@ exports[`action runAction push to production or staging env/prod tagging Non-Exi
     "##[info] Creating and pushing new tag v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0",
@@ -1346,7 +1397,10 @@ exports[`action runAction push to production or staging env/staging deployments 
     "##[info] Checking if there is an existing tag for v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0-pre",
@@ -1370,10 +1424,10 @@ exports[`action runAction push to production or staging env/staging deployments 
     "##[info] Tag has not been created, okay to continue",
   ],
   [
-    "##[info] Pushing image to docker repository",
+    "##[info] Pushing image to docker repository hpc-actions/unit-test",
   ],
   [
-    "##[info] Image Pushed",
+    "##[info] Image hpc-actions/unit-test:v1.2.0-pre pushed",
   ],
   [
     "##[info] Creating staging deployment",
@@ -1414,7 +1468,10 @@ exports[`action runAction push to production or staging env/staging deployments 
     "##[info] Checking if there is an existing tag for v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0-pre",
@@ -1438,10 +1495,10 @@ exports[`action runAction push to production or staging env/staging deployments 
     "##[info] Tag has not been created, okay to continue",
   ],
   [
-    "##[info] Pushing image to docker repository",
+    "##[info] Pushing image to docker repository hpc-actions/unit-test",
   ],
   [
-    "##[info] Image Pushed",
+    "##[info] Image hpc-actions/unit-test:v1.2.0-pre pushed",
   ],
   [
     "##[info] Creating and pushing mergeback Branch: mergeback/staging/1.2.0",
@@ -1479,7 +1536,10 @@ exports[`action runAction push to production or staging env/staging docker Exist
     "##[info] Checking if there is an existing tag for v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0-pre",
@@ -1539,7 +1599,10 @@ exports[`action runAction push to production or staging env/staging docker Exist
     "##[info] The tag is for the current commit, okay to continue",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0-pre",
@@ -1566,7 +1629,7 @@ exports[`action runAction push to production or staging env/staging docker Exist
     "##[info] Tag is unchanged, okay to continue",
   ],
   [
-    "##[info] Pushing image to docker repository",
+    "##[info] Pushing image to docker repository hpc-actions/unit-test",
   ],
 ]
 `;
@@ -1611,7 +1674,10 @@ exports[`action runAction push to production or staging env/staging docker Exist
     "##[info] Checking if there is an existing tag for v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0-pre",
@@ -1638,7 +1704,7 @@ exports[`action runAction push to production or staging env/staging docker Exist
     "##[info] Tag has not been created, okay to continue",
   ],
   [
-    "##[info] Pushing image to docker repository",
+    "##[info] Pushing image to docker repository hpc-actions/unit-test",
   ],
 ]
 `;
@@ -1683,7 +1749,10 @@ exports[`action runAction push to production or staging env/staging docker Exist
     "##[info] Checking if there is an existing tag for v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0-pre",
@@ -1737,7 +1806,10 @@ exports[`action runAction push to production or staging env/staging docker Exist
     "##[info] Checking if there is an existing tag for v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0-pre",
@@ -1782,7 +1854,10 @@ exports[`action runAction push to production or staging env/staging docker Non-E
     "##[info] Checking if there is an existing tag for v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0-pre",
@@ -1830,7 +1905,10 @@ exports[`action runAction push to production or staging env/staging docker Non-E
     "##[info] Checking if there is an existing tag for v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0-pre",
@@ -1854,10 +1932,10 @@ exports[`action runAction push to production or staging env/staging docker Non-E
     "##[info] Tag has not been created, okay to continue",
   ],
   [
-    "##[info] Pushing image to docker repository",
+    "##[info] Pushing image to docker repository hpc-actions/unit-test",
   ],
   [
-    "##[info] Image Pushed",
+    "##[info] Image hpc-actions/unit-test:v1.2.0-pre pushed",
   ],
   [
     "##[info] Creating and pushing mergeback Branch: mergeback/staging/1.2.0",
@@ -1897,7 +1975,10 @@ exports[`action runAction push to production or staging env/staging mergeback 1`
     "##[info] Checking if there is an existing tag for v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0-pre",
@@ -1921,10 +2002,10 @@ exports[`action runAction push to production or staging env/staging mergeback 1`
     "##[info] Tag has not been created, okay to continue",
   ],
   [
-    "##[info] Pushing image to docker repository",
+    "##[info] Pushing image to docker repository hpc-actions/unit-test",
   ],
   [
-    "##[info] Image Pushed",
+    "##[info] Image hpc-actions/unit-test:v1.2.0-pre pushed",
   ],
   [
     "##[info] Creating and pushing mergeback Branch: mergeback/staging/1.2.0",
@@ -1982,7 +2063,10 @@ exports[`action runAction push to production or staging env/staging tagging Exis
     "##[info] The tag is for the current commit, okay to continue",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0-pre",
@@ -2005,7 +2089,10 @@ exports[`action runAction push to production or staging env/staging tagging Exis
     "##[info] The current tree matches the existing tag, okay to continue",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0-pre",
@@ -2022,7 +2109,10 @@ exports[`action runAction push to production or staging env/staging tagging Non-
     "##[info] Checking if there is an existing tag for v1.2.0",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Checking for existing docker image with tag v1.2.0-pre",
@@ -2072,7 +2162,10 @@ exports[`action runAction push to release/<name> branch Successful release 1`] =
     "##[info] Checking if there is an existing tag for v1.2.1",
   ],
   [
-    "##[info] Logging in to docker",
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
   ],
   [
     "##[info] Skipping check for existing image with tag v1.2.1-pre, building new image",
@@ -2084,10 +2177,10 @@ exports[`action runAction push to release/<name> branch Successful release 1`] =
     "##[info] Tag has not been created, okay to continue",
   ],
   [
-    "##[info] Pushing image to docker repository",
+    "##[info] Pushing image to docker repository hpc-actions/unit-test",
   ],
   [
-    "##[info] Image Pushed",
+    "##[info] Image hpc-actions/unit-test:v1.2.1-pre pushed",
   ],
   [
     "##[info] Running CI Checks",
@@ -2112,7 +2205,7 @@ exports[`action runAction push to release/<name> branch Successful release 3`] =
 [
   [
     {
-      "body": "Docker image has been successfully built and pushed as: \`:v1.2.1-pre\`
+      "body": "Docker image has been successfully built and pushed as: \`hpc-actions/unit-test:v1.2.1-pre\`
 
 Please deploy this image to a development environment, and test it is working as expected before merging this pull request.",
       "pullRequestNumber": 321,

--- a/action/test/specs/__snapshots__/action.spec.ts.snap
+++ b/action/test/specs/__snapshots__/action.spec.ts.snap
@@ -1101,6 +1101,121 @@ exports[`action runAction push to production or staging env/prod docker Existing
 ]
 `;
 
+exports[`action runAction push to production or staging env/prod docker Multiple non-existant images 1`] = `
+[
+  [
+    "##[info] Handling push to branch env/prod",
+  ],
+  [
+    "##[info] Checking if there is an existing tag for v1.2.0",
+  ],
+  [
+    "##[info] Creating and pushing new tag v1.2.0",
+  ],
+  [
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
+  ],
+  [
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
+  ],
+  [
+    "##[info] Checking for existing docker image with tag v1.2.0",
+  ],
+  [
+    "##[info] Checking for existing docker image with tag v1.2.0",
+  ],
+  [
+    "##[info] Image with tag v1.2.0 does not yet exist",
+  ],
+  [
+    "##[info] Checking for existing docker image with tag v1.2.0-pre",
+  ],
+  [
+    "##[info] Image with tag v1.2.0 does not yet exist",
+  ],
+  [
+    "##[info] Checking for existing docker image with tag v1.2.0-pre",
+  ],
+  [
+    "##[info] No image exists with this tag",
+  ],
+  [
+    "##[info] Building new image",
+  ],
+  [
+    "##[info] No image exists with this tag",
+  ],
+  [
+    "##[info] Building new image",
+  ],
+  [
+    "##[info] Image built, checking tag v1.2.0 is unchanged",
+  ],
+  [
+    "##[info] Image built, checking tag v1.2.0 is unchanged",
+  ],
+  [
+    "##[info] Tag is unchanged, okay to continue",
+  ],
+  [
+    "##[info] Pushing image to docker repository hpc-actions/unit-test-1",
+  ],
+  [
+    "##[info] Image hpc-actions/unit-test-1:v1.2.0 pushed",
+  ],
+  [
+    "##[info] Tag is unchanged, okay to continue",
+  ],
+  [
+    "##[info] Pushing image to docker repository hpc-actions/unit-test-2",
+  ],
+  [
+    "##[info] Image hpc-actions/unit-test-2:v1.2.0 pushed",
+  ],
+  [
+    "##[info] Creating and pushing mergeback Branch: mergeback/prod/1.2.0",
+  ],
+  [
+    "##[info] Opening Mergeback Pull Request",
+  ],
+]
+`;
+
+exports[`action runAction push to production or staging env/prod docker Multiple non-existant images 2`] = `
+{
+  "getMetadata": [],
+  "pullImage": [
+    [
+      "v1.2.0",
+    ],
+    [
+      "v1.2.0",
+    ],
+    [
+      "v1.2.0-pre",
+    ],
+    [
+      "v1.2.0-pre",
+    ],
+  ],
+  "pushImage": [
+    [
+      "v1.2.0",
+    ],
+    [
+      "v1.2.0",
+    ],
+  ],
+  "retagImage": [],
+}
+`;
+
 exports[`action runAction push to production or staging env/prod docker Non-Existant Image (tag changed) 1`] = `
 [
   [
@@ -1843,6 +1958,118 @@ exports[`action runAction push to production or staging env/staging docker Exist
     "v1.2.0-pre",
   ],
 ]
+`;
+
+exports[`action runAction push to production or staging env/staging docker Multiple non-existant images 1`] = `
+[
+  [
+    "##[info] Handling push to branch env/staging",
+  ],
+  [
+    "##[info] Checking if there is an existing tag for v1.2.0",
+  ],
+  [
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
+  ],
+  [
+    "##[info] Initializing Docker controller",
+  ],
+  [
+    "##[info] Logging in to Docker",
+  ],
+  [
+    "##[info] Checking for existing docker image with tag v1.2.0-pre",
+  ],
+  [
+    "##[info] Checking for existing docker image with tag v1.2.0-pre",
+  ],
+  [
+    "##[info] Image with tag v1.2.0-pre does not yet exist",
+  ],
+  [
+    "##[info] Checking for existing docker image with tag v1.2.0",
+  ],
+  [
+    "##[info] Image with tag v1.2.0-pre does not yet exist",
+  ],
+  [
+    "##[info] Checking for existing docker image with tag v1.2.0",
+  ],
+  [
+    "##[info] No image exists with this tag",
+  ],
+  [
+    "##[info] Building new image",
+  ],
+  [
+    "##[info] No image exists with this tag",
+  ],
+  [
+    "##[info] Building new image",
+  ],
+  [
+    "##[info] Image built, checking tag v1.2.0 still does not exist",
+  ],
+  [
+    "##[info] Image built, checking tag v1.2.0 still does not exist",
+  ],
+  [
+    "##[info] Tag has not been created, okay to continue",
+  ],
+  [
+    "##[info] Pushing image to docker repository hpc-actions/unit-test-1",
+  ],
+  [
+    "##[info] Image hpc-actions/unit-test-1:v1.2.0-pre pushed",
+  ],
+  [
+    "##[info] Tag has not been created, okay to continue",
+  ],
+  [
+    "##[info] Pushing image to docker repository hpc-actions/unit-test-2",
+  ],
+  [
+    "##[info] Image hpc-actions/unit-test-2:v1.2.0-pre pushed",
+  ],
+  [
+    "##[info] Creating and pushing mergeback Branch: mergeback/staging/1.2.0",
+  ],
+  [
+    "##[info] Opening Mergeback Pull Request",
+  ],
+]
+`;
+
+exports[`action runAction push to production or staging env/staging docker Multiple non-existant images 2`] = `
+{
+  "getMetadata": [],
+  "pullImage": [
+    [
+      "v1.2.0-pre",
+    ],
+    [
+      "v1.2.0-pre",
+    ],
+    [
+      "v1.2.0",
+    ],
+    [
+      "v1.2.0",
+    ],
+  ],
+  "pushImage": [
+    [
+      "v1.2.0-pre",
+    ],
+    [
+      "v1.2.0-pre",
+    ],
+  ],
+  "retagImage": [],
+}
 `;
 
 exports[`action runAction push to production or staging env/staging docker Non-Existant Image (tag changed) 1`] = `

--- a/action/test/specs/action.spec.ts
+++ b/action/test/specs/action.spec.ts
@@ -24,18 +24,20 @@ const DEFAULT_CONFIG: Config = {
   stagingEnvironmentBranch: 'env/staging',
   repoType: 'node',
   developmentEnvironmentBranches: ['env/dev'],
-  docker: {
-    path: '.',
-    args: {
-      commitSha: '',
-      treeSha: '',
+  dockerImages: [
+    {
+      dockerfilePath: '.',
+      args: {
+        commitSha: '',
+        treeSha: '',
+      },
+      environmentVariables: {
+        commitSha: '',
+        treeSha: '',
+      },
+      repository: '',
     },
-    environmentVariables: {
-      commitSha: '',
-      treeSha: '',
-    },
-    repository: '',
-  },
+  ],
   ci: [],
   mergebackLabels: ['some-label'],
 };

--- a/action/test/specs/action.spec.ts
+++ b/action/test/specs/action.spec.ts
@@ -934,6 +934,111 @@ describe('action', () => {
                 ],
               ]);
             });
+
+            it('Multiple non-existant images', async () => {
+              const upstream = await util.createTmpDir();
+              const dir = await util.createTmpDir();
+              // Prepare upstream repository
+              await git.init({ fs, dir: upstream });
+              await fs.promises.writeFile(
+                path.join(upstream, 'package.json'),
+                JSON.stringify({
+                  version: '1.2.0',
+                })
+              );
+              await git.add({ fs, dir: upstream, filepath: 'package.json' });
+              await setAuthor(upstream);
+              await exec('git commit -m package', { cwd: upstream });
+              await git.branch({ fs, dir: upstream, ref: `env/${env}` });
+              // Clone into repo we'll run in, and create appropriate branch
+              await exec(`git clone --branch env/${env} ${upstream} ${dir}`);
+              // Run action
+              const config: Config = {
+                ...DEFAULT_CONFIG,
+                dockerImages: [
+                  {
+                    ...DEFAULT_CONFIG.dockerImages[0],
+                    appName: 'unit-test-1',
+                    repository: 'hpc-actions/unit-test-1',
+                  },
+                  {
+                    ...DEFAULT_CONFIG.dockerImages[0],
+                    appName: 'unit-test-2',
+                    repository: 'hpc-actions/unit-test-2',
+                  },
+                ],
+              };
+              await fs.promises.writeFile(CONFIG_FILE, JSON.stringify(config));
+              await fs.promises.writeFile(
+                EVENT_FILE,
+                JSON.stringify({
+                  ref: `refs/heads/env/${env}`,
+                })
+              );
+              const logger = util.newLogger();
+              // Prepare docker mock
+              const pullImage = jest.fn().mockResolvedValue(null);
+              const getMetadata = jest.fn().mockResolvedValue(null);
+              const runBuild = jest.fn().mockResolvedValue(null);
+              const retagImage = jest.fn().mockResolvedValue(null);
+              const pushImage = jest.fn().mockResolvedValue(null);
+              await action
+                .runAction({
+                  env: DEFAULT_ENV,
+                  dir,
+                  logger,
+                  dockerInit: () => ({
+                    login: () => Promise.resolve(),
+                    pullImage,
+                    getMetadata,
+                    runBuild,
+                    retagImage,
+                    pushImage,
+                  }),
+                  gitHubInit: testCompleteGitHubInit,
+                })
+                .then(() => {
+                  throw new Error('Expected error to be thrown');
+                })
+                .catch((error) => expect(error).toBe(testCompleteError));
+              expect(logger.log.mock.calls).toMatchSnapshot();
+              expect({
+                pullImage: pullImage.mock.calls.map((call) => [call[0]]),
+                getMetadata: getMetadata.mock.calls,
+                retagImage: retagImage.mock.calls,
+                pushImage: pushImage.mock.calls,
+              }).toMatchSnapshot();
+              const sha = await git.resolveRef({ fs, dir, ref: 'HEAD' });
+              const head = await git.readCommit({ fs, dir, oid: sha });
+              const args1: DockerImageBuildArgs = {
+                commitSha: head.oid,
+                treeSha: head.commit.tree,
+                appToBuild: 'unit-test-1',
+              };
+              const args2: DockerImageBuildArgs = {
+                commitSha: head.oid,
+                treeSha: head.commit.tree,
+                appToBuild: 'unit-test-2',
+              };
+              expect(runBuild.mock.calls).toEqual([
+                [
+                  {
+                    cwd: dir,
+                    logger,
+                    tag: env === 'prod' ? 'v1.2.0' : 'v1.2.0-pre',
+                    args: args1,
+                  },
+                ],
+                [
+                  {
+                    cwd: dir,
+                    logger,
+                    tag: env === 'prod' ? 'v1.2.0' : 'v1.2.0-pre',
+                    args: args2,
+                  },
+                ],
+              ]);
+            });
           });
 
           describe('deployments + mergeback', () => {

--- a/action/test/specs/action.spec.ts
+++ b/action/test/specs/action.spec.ts
@@ -35,7 +35,7 @@ const DEFAULT_CONFIG: Config = {
         commitSha: '',
         treeSha: '',
       },
-      repository: '',
+      repository: 'hpc-actions/unit-test',
     },
   ],
   ci: [],

--- a/action/test/specs/action.spec.ts
+++ b/action/test/specs/action.spec.ts
@@ -30,6 +30,7 @@ const DEFAULT_CONFIG: Config = {
       args: {
         commitSha: '',
         treeSha: '',
+        appToBuild: '',
       },
       environmentVariables: {
         commitSha: '',
@@ -956,6 +957,12 @@ describe('action', () => {
               // Run action
               const config: Config = {
                 ...DEFAULT_CONFIG,
+                dockerImages: [
+                  {
+                    ...DEFAULT_CONFIG.dockerImages[0],
+                    appName: 'unit-test',
+                  },
+                ],
                 deployments: {
                   environments: [
                     {
@@ -1003,7 +1010,7 @@ describe('action', () => {
                     environment: env,
                     payload: {
                       docker_tag: env === 'prod' ? 'v1.2.0' : 'v1.2.0-pre',
-                      repository_name: undefined,
+                      repository_name: 'unit-test',
                     },
                     production_environment: env === 'prod',
                     // TODO: test this more thoroughly

--- a/action/test/specs/action.spec.ts
+++ b/action/test/specs/action.spec.ts
@@ -10,7 +10,7 @@ import * as action from '../../src/action';
 import type { Config, Env } from '../../src/config';
 import type {
   DockerController,
-  DockerImageMetadata,
+  DockerImageBuildArgs,
   DockerInit,
 } from '../../src/docker';
 import type { GitHubController, GitHubInit } from '../../src/github';
@@ -448,7 +448,7 @@ describe('action', () => {
               // Prepare docker mock
               const sha = await git.resolveRef({ fs, dir, ref: 'HEAD' });
               const head = await git.readCommit({ fs, dir, oid: sha });
-              const meta: DockerImageMetadata = {
+              const args: DockerImageBuildArgs = {
                 commitSha: head.oid,
                 treeSha: head.commit.tree,
               };
@@ -456,7 +456,7 @@ describe('action', () => {
               const getMetadata = jest
                 .fn()
                 .mockImplementation((tag: string) =>
-                  tag === 'v1.2.0' ? meta : null
+                  tag === 'v1.2.0' ? args : null
                 );
               const retagImage = jest.fn().mockResolvedValue(true);
               await action
@@ -523,7 +523,7 @@ describe('action', () => {
               // Prepare docker mock
               const sha = await git.resolveRef({ fs, dir, ref: 'HEAD' });
               const head = await git.readCommit({ fs, dir, oid: sha });
-              const meta: DockerImageMetadata = {
+              const args: DockerImageBuildArgs = {
                 commitSha: head.oid,
                 treeSha: head.commit.tree,
               };
@@ -531,7 +531,7 @@ describe('action', () => {
               const getMetadata = jest
                 .fn()
                 .mockImplementation((tag: string) =>
-                  tag === 'v1.2.0' ? meta : null
+                  tag === 'v1.2.0' ? args : null
                 );
               const retagImage = jest.fn().mockResolvedValue(true);
               await action
@@ -589,7 +589,7 @@ describe('action', () => {
               );
               const logger = util.newLogger();
               // Prepare docker mock
-              const meta: DockerImageMetadata = {
+              const args: DockerImageBuildArgs = {
                 commitSha: 'foo',
                 treeSha: 'bar',
               };
@@ -597,7 +597,7 @@ describe('action', () => {
               const getMetadata = jest
                 .fn()
                 .mockImplementation((tag: string) =>
-                  tag === 'v1.2.0' ? meta : null
+                  tag === 'v1.2.0' ? args : null
                 );
               await action
                 .runAction({
@@ -661,7 +661,7 @@ describe('action', () => {
               // Prepare docker mock
               const sha = await git.resolveRef({ fs, dir, ref: 'HEAD' });
               const head = await git.readCommit({ fs, dir, oid: sha });
-              const meta: DockerImageMetadata = {
+              const args: DockerImageBuildArgs = {
                 commitSha: head.oid,
                 treeSha: head.commit.tree,
               };
@@ -669,7 +669,7 @@ describe('action', () => {
               const getMetadata = jest
                 .fn()
                 .mockImplementation((tag: string) =>
-                  tag === 'v1.2.0-pre' ? meta : null
+                  tag === 'v1.2.0-pre' ? args : null
                 );
               await action
                 .runAction({
@@ -724,7 +724,7 @@ describe('action', () => {
               );
               const logger = util.newLogger();
               // Prepare docker mock
-              const meta: DockerImageMetadata = {
+              const args: DockerImageBuildArgs = {
                 commitSha: 'foo',
                 treeSha: 'bar',
               };
@@ -732,7 +732,7 @@ describe('action', () => {
               const getMetadata = jest
                 .fn()
                 .mockImplementation((tag: string) =>
-                  tag === 'v1.2.0-pre' ? meta : null
+                  tag === 'v1.2.0-pre' ? args : null
                 );
               await action
                 .runAction({
@@ -820,7 +820,7 @@ describe('action', () => {
               }).toMatchSnapshot();
               const sha = await git.resolveRef({ fs, dir, ref: 'HEAD' });
               const head = await git.readCommit({ fs, dir, oid: sha });
-              const meta: DockerImageMetadata = {
+              const args: DockerImageBuildArgs = {
                 commitSha: head.oid,
                 treeSha: head.commit.tree,
               };
@@ -830,7 +830,7 @@ describe('action', () => {
                     cwd: dir,
                     logger,
                     tag: env === 'prod' ? 'v1.2.0' : 'v1.2.0-pre',
-                    meta,
+                    args,
                   },
                 ],
               ]);
@@ -916,7 +916,7 @@ describe('action', () => {
               }).toMatchSnapshot();
               const sha = await git.resolveRef({ fs, dir, ref: 'HEAD' });
               const head = await git.readCommit({ fs, dir, oid: sha });
-              const meta: DockerImageMetadata = {
+              const args: DockerImageBuildArgs = {
                 commitSha: head.oid,
                 treeSha: head.commit.tree,
               };
@@ -926,7 +926,7 @@ describe('action', () => {
                     cwd: dir,
                     logger,
                     tag: env === 'prod' ? 'v1.2.0' : 'v1.2.0-pre',
-                    meta,
+                    args,
                   },
                 ],
               ]);
@@ -1274,7 +1274,7 @@ describe('action', () => {
         expect(pushImage.mock.calls).toEqual([['env-dev']]);
         const sha = await git.resolveRef({ fs, dir, ref: 'HEAD' });
         const head = await git.readCommit({ fs, dir, oid: sha });
-        const meta: DockerImageMetadata = {
+        const args: DockerImageBuildArgs = {
           commitSha: head.oid,
           treeSha: head.commit.tree,
         };
@@ -1284,7 +1284,7 @@ describe('action', () => {
               cwd: dir,
               logger,
               tag: 'env-dev',
-              meta,
+              args,
             },
           ],
         ]);
@@ -1725,7 +1725,7 @@ describe('action', () => {
         }).toMatchSnapshot();
         const sha = await git.resolveRef({ fs, dir, ref: 'HEAD' });
         const head = await git.readCommit({ fs, dir, oid: sha });
-        const meta: DockerImageMetadata = {
+        const args: DockerImageBuildArgs = {
           commitSha: head.oid,
           treeSha: head.commit.tree,
         };
@@ -1735,7 +1735,7 @@ describe('action', () => {
               cwd: dir,
               logger,
               tag: 'v1.2.1-pre',
-              meta,
+              args,
             },
           ],
         ]);
@@ -1828,7 +1828,7 @@ describe('action', () => {
         }).toMatchSnapshot();
         const sha = await git.resolveRef({ fs, dir, ref: 'HEAD' });
         const head = await git.readCommit({ fs, dir, oid: sha });
-        const meta: DockerImageMetadata = {
+        const args: DockerImageBuildArgs = {
           commitSha: head.oid,
           treeSha: head.commit.tree,
         };
@@ -1838,7 +1838,7 @@ describe('action', () => {
               cwd: dir,
               logger,
               tag: 'v1.2.1-pre',
-              meta,
+              args,
             },
           ],
         ]);
@@ -1935,7 +1935,7 @@ describe('action', () => {
         }).toMatchSnapshot();
         const sha = await git.resolveRef({ fs, dir, ref: 'HEAD' });
         const head = await git.readCommit({ fs, dir, oid: sha });
-        const meta: DockerImageMetadata = {
+        const args: DockerImageBuildArgs = {
           commitSha: head.oid,
           treeSha: head.commit.tree,
         };
@@ -1945,7 +1945,7 @@ describe('action', () => {
               cwd: dir,
               logger,
               tag: 'v1.2.1-pre',
-              meta,
+              args,
             },
           ],
         ]);
@@ -2104,7 +2104,7 @@ describe('action', () => {
         }).toMatchSnapshot();
         const sha = await git.resolveRef({ fs, dir, ref: 'HEAD' });
         const head = await git.readCommit({ fs, dir, oid: sha });
-        const meta: DockerImageMetadata = {
+        const args: DockerImageBuildArgs = {
           commitSha: head.oid,
           treeSha: head.commit.tree,
         };
@@ -2114,7 +2114,7 @@ describe('action', () => {
               cwd: dir,
               logger,
               tag: 'v1.2.1-pre',
-              meta,
+              args,
             },
           ],
         ]);

--- a/action/test/specs/config.spec.ts
+++ b/action/test/specs/config.spec.ts
@@ -80,9 +80,11 @@ describe('config', () => {
       dockerImages: [
         {
           dockerfilePath: '.',
+          appName: 'unit-test',
           args: {
             commitSha: '',
             treeSha: '',
+            appToBuild: '',
           },
           environmentVariables: {
             commitSha: '',
@@ -119,9 +121,11 @@ describe('config', () => {
       dockerImages: [
         {
           dockerfilePath: '.',
+          appName: 'unit-test',
           args: {
             commitSha: '',
             treeSha: '',
+            appToBuild: '',
           },
           environmentVariables: {
             commitSha: '',
@@ -157,9 +161,11 @@ describe('config', () => {
       dockerImages: [
         {
           dockerfilePath: '.',
+          appName: 'unit-test',
           args: {
             commitSha: '',
             treeSha: '',
+            appToBuild: '',
           },
           environmentVariables: {
             commitSha: '',

--- a/action/test/specs/config.spec.ts
+++ b/action/test/specs/config.spec.ts
@@ -77,19 +77,21 @@ describe('config', () => {
       stagingEnvironmentBranch: 'env/stage',
       repoType: 'node',
       developmentEnvironmentBranches: [],
-      docker: {
-        path: '.',
-        args: {
-          commitSha: '',
-          treeSha: '',
+      dockerImages: [
+        {
+          dockerfilePath: '.',
+          args: {
+            commitSha: '',
+            treeSha: '',
+          },
+          environmentVariables: {
+            commitSha: '',
+            treeSha: '',
+          },
+          repository: 'user/repo',
+          registry: 'docker.pkg.github.com',
         },
-        environmentVariables: {
-          commitSha: '',
-          treeSha: '',
-        },
-        repository: 'user/repo',
-        registry: 'docker.pkg.github.com',
-      },
+      ],
       ci: [],
     };
 
@@ -114,18 +116,20 @@ describe('config', () => {
       stagingEnvironmentBranch: 'env/stage',
       repoType: 'node',
       developmentEnvironmentBranches: ['dev'],
-      docker: {
-        path: '.',
-        args: {
-          commitSha: '',
-          treeSha: '',
+      dockerImages: [
+        {
+          dockerfilePath: '.',
+          args: {
+            commitSha: '',
+            treeSha: '',
+          },
+          environmentVariables: {
+            commitSha: '',
+            treeSha: '',
+          },
+          repository: '',
         },
-        environmentVariables: {
-          commitSha: '',
-          treeSha: '',
-        },
-        repository: '',
-      },
+      ],
       ci: [],
     };
 
@@ -150,18 +154,20 @@ describe('config', () => {
       stagingEnvironmentBranch: 'env/stage',
       repoType: 'node',
       developmentEnvironmentBranches: ['env/dev1', 'env/dev2'],
-      docker: {
-        path: '.',
-        args: {
-          commitSha: '',
-          treeSha: '',
+      dockerImages: [
+        {
+          dockerfilePath: '.',
+          args: {
+            commitSha: '',
+            treeSha: '',
+          },
+          environmentVariables: {
+            commitSha: '',
+            treeSha: '',
+          },
+          repository: '',
         },
-        environmentVariables: {
-          commitSha: '',
-          treeSha: '',
-        },
-        repository: '',
-      },
+      ],
       ci: [],
     };
 

--- a/action/test/specs/docker.spec.ts
+++ b/action/test/specs/docker.spec.ts
@@ -23,9 +23,11 @@ describe('docker', () => {
 
     const docker = REAL_DOCKER({
       dockerfilePath: './docker',
+      appName: 'unit-test',
       args: {
         commitSha: 'COMMIT_SHA',
         treeSha: 'TREE_SHA',
+        appToBuild: 'APP_TO_BUILD',
       },
       environmentVariables: {
         commitSha: 'HPC_ACTIONS_COMMIT_SHA',
@@ -43,6 +45,7 @@ describe('docker', () => {
         args: {
           commitSha: 'foo',
           treeSha: 'bar',
+          appToBuild: 'unit-test',
         },
         logger,
       })

--- a/action/test/specs/docker.spec.ts
+++ b/action/test/specs/docker.spec.ts
@@ -40,7 +40,7 @@ describe('docker', () => {
       .runBuild({
         cwd: dir,
         tag: 'some-tag',
-        meta: {
+        args: {
           commitSha: 'foo',
           treeSha: 'bar',
         },

--- a/action/test/specs/docker.spec.ts
+++ b/action/test/specs/docker.spec.ts
@@ -22,7 +22,7 @@ describe('docker', () => {
     await fs.writeFile(path.join(dir, 'docker', 'Dockerfile'), DOCKER_FILE);
 
     const docker = REAL_DOCKER({
-      path: './docker',
+      dockerfilePath: './docker',
       args: {
         commitSha: 'COMMIT_SHA',
         treeSha: 'TREE_SHA',

--- a/action/test/specs/docker.spec.ts
+++ b/action/test/specs/docker.spec.ts
@@ -6,7 +6,7 @@ import * as util from '../util';
 import { REAL_DOCKER } from '../../src/docker';
 
 const DOCKER_FILE = `
-FROM alpine:3.16
+FROM alpine:3.19
 
 ARG COMMIT_SHA
 ARG TREE_SHA


### PR DESCRIPTION
Until this PR, this custom GitHub Action assumed there is a one-to-one relationship between a repository and deployable Docker image. But, since [CDM](https://github.com/UN-OCHA/hpc-cdm) is a monorepo, there are (up to) two applications which can be deployed from the same repository. The goal of this PR is to add support for monorepos.

Even though this change is made to tailor needs of CDM monorepo, this Action doesn't need to know the details of any specific monorepo. The idea is to allow specification of multiple buildable images and accept a parameter which apps to deploy. Unless specified, all listed applications will be deployed. But, one implementation detail from CDM has leaked into the design decisions made in this PR. Namely, CDM is using [Nx](https://nx.dev/) for monorepo management, and we are embracing its single version policy, so we’re using a single `package.json` file at the top-level, where all the dependencies are specified and single version is defined, to be used by all applications inside a monorepo.

That version will be used when creating git tags after each release. The same tag will be used for tagging Docker images after building them, but only the application which has changes (if specified) will be deployed. That means that individual apps can have gaps in Docker tagged versions. This decision was made because we wanted to skip building + releasing overhead when there isn’t anything new to release.

Releasing new version is done by merging into a specific branch, tied to the given environment. Development environments are supposed to get all apps deployed. After merging into a specific branch, this action will build image(s), push to AWS ECR and create deployment(s) on GitHub. In each of the repositories using this action, when a deployment is created on GitHub, a webhook is triggered and it sends a generic HTTP request with payload to Jenkins. Jenkins then deploys Docker image into the environment in question. This job previously assumed that app being deployed is same as repository name, but since #55 we're sending this information in payload too.