### PR TITLE
Make "existing tag" error message more readable

### DIFF
--- a/action/dist/index.js
+++ b/action/dist/index.js
@@ -427,9 +427,9 @@ const runAction = async ({ env, dir = process.cwd(), logger = console, dockerIni
                 await failWithPRComment({
                     error: `Tag already exists for version ${tag}, aborting.`,
                     pullRequest,
-                    comment: `There is already a tag for version ${tag},` +
+                    comment: `There is already a tag for version ${tag}, ` +
                         "so we can't create another release with the same version.\n\n" +
-                        `Please update the version in \`${file}\`\n\n to something ` +
+                        `Please update the version in \`${file}\` to something ` +
                         'that has not yet had peen deployed to `env/prod` ' +
                         `or \`${config.stagingEnvironmentBranch}\`.`,
                 });

--- a/action/src/action.ts
+++ b/action/src/action.ts
@@ -568,9 +568,9 @@ export const runAction = async ({
           error: `Tag already exists for version ${tag}, aborting.`,
           pullRequest,
           comment:
-            `There is already a tag for version ${tag},` +
+            `There is already a tag for version ${tag}, ` +
             "so we can't create another release with the same version.\n\n" +
-            `Please update the version in \`${file}\`\n\n to something ` +
+            `Please update the version in \`${file}\` to something ` +
             'that has not yet had peen deployed to `env/prod` ' +
             `or \`${config.stagingEnvironmentBranch}\`.`,
         });

--- a/action/test/specs/__snapshots__/action.spec.ts.snap
+++ b/action/test/specs/__snapshots__/action.spec.ts.snap
@@ -285,11 +285,9 @@ exports[`action runAction push to hotfix/<name> branch Tag already exists 3`] = 
 [
   [
     {
-      "body": "There is already a tag for version v1.2.1,so we can't create another release with the same version.
+      "body": "There is already a tag for version v1.2.1, so we can't create another release with the same version.
 
-Please update the version in \`package.json\`
-
- to something that has not yet had peen deployed to \`env/prod\` or \`env/staging\`.",
+Please update the version in \`package.json\` to something that has not yet had peen deployed to \`env/prod\` or \`env/staging\`.",
       "pullRequestNumber": 321,
       "state": "reject",
     },


### PR DESCRIPTION
Motivated by [this error message](https://github.com/UN-OCHA/rpm/pull/758#pullrequestreview-2309473270). Space after comma is making the sentence more readable and so is the lack of newline in the middle of it.