### PR TITLE
Stop using `GITHUB_TOKEN` system reserved name

### DIFF
--- a/.github/workflows/stage-release.yml
+++ b/.github/workflows/stage-release.yml
@@ -11,7 +11,7 @@ on:
         type: string
         default: "patch"
     secrets:
-      GITHUB_TOKEN:
+      GH_TOKEN:
         description: "GitHub token"
         required: true
 
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           gh pr create --base env/stage \
           --head ${{ steps.bump_version.outputs.release_branch }} \


### PR DESCRIPTION
When reviewing #96, I changed `GH_TOKEN` variable name to `GITHUB_TOKEN`, thinking it will be more clear what it is, but turns out that is a system reserved name, so the first run of the action in hpc-api which uses this shared GitHub Action [has failed](https://github.com/UN-OCHA/hpc-api/actions/runs/13768946841/workflow) with following message:
> secret name `GITHUB_TOKEN` within `workflow_call` can not be used since it would collide with system reserved name