### PR TITLE
Remove `author` field

### DIFF
--- a/.github/workflows/stage-release.yml
+++ b/.github/workflows/stage-release.yml
@@ -1,6 +1,5 @@
 name: "Stage Release Action"
 description: "Reusable GitHub Action to create stage release PRs"
-author: enxtur <enxtur.mon@gmail.com>
 
 on:
   workflow_call:


### PR DESCRIPTION
After using reserved variable name (#109), I broke the job by making another change in Enkhtur's original work (#96), because I added `author` field to the workflow, wanting to give credits to Enkhtur, but running the workflow in hpc-api [has failed](https://github.com/UN-OCHA/hpc-api/actions/runs/13769130265) with:
> Error from called workflow UN-OCHA/hpc-actions/.github/workflows/stage-release.yml@develop (Line: 3, Col: 1): Unexpected value 'author'